### PR TITLE
feat: introduce eXo parent pom - EXO-64103

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>addons-parent-pom</artifactId>
+        <artifactId>addons-parent-exo-pom</artifactId>
         <groupId>org.exoplatform.addons</groupId>
-        <version>17-exo-M01</version>
+        <version>17-security-fix-SNAPSHOT</version>
     </parent>
     <groupId>org.exoplatform.anti-malware</groupId>
     <artifactId>anti-malware</artifactId>
@@ -15,9 +15,7 @@
     <name>eXo Anti-Malware - Parent</name>
 
     <properties>
-        <org.exoplatform.commons.version>6.5.x-exo-SNAPSHOT</org.exoplatform.commons.version>
         <addon.exo.ecms.version>6.5.x-SNAPSHOT</addon.exo.ecms.version>
-        <org.exoplatform.gatein.portal.version>6.5.x-exo-SNAPSHOT</org.exoplatform.gatein.portal.version>
     </properties>
 
     <modules>
@@ -33,20 +31,6 @@
     </scm>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.exoplatform.gatein.portal</groupId>
-                <artifactId>exo.portal.parent</artifactId>
-                <version>${org.exoplatform.gatein.portal.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.exoplatform.commons</groupId>
-                <artifactId>commons</artifactId>
-                <version>${org.exoplatform.commons.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>org.exoplatform.ecms</groupId>
                 <artifactId>ecms</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>addons-exo-parent-pom</artifactId>
         <groupId>org.exoplatform.addons</groupId>
-        <version>17-security-fix-SNAPSHOT</version>
+        <version>17-M01</version>
     </parent>
     <groupId>org.exoplatform.anti-malware</groupId>
     <artifactId>anti-malware</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>addons-parent-exo-pom</artifactId>
+        <artifactId>addons-exo-parent-pom</artifactId>
         <groupId>org.exoplatform.addons</groupId>
         <version>17-security-fix-SNAPSHOT</version>
     </parent>


### PR DESCRIPTION
This feature introduce new parent pom for eXo to be able to declare libraries versions used only in eXo, without impacting meeds