### PR TITLE
fix: Truncate ClamAV report instead of delete after being processed - EXO-82805 - exoplatform#eXIP29

### DIFF
--- a/anti-malware-services/src/main/java/org/exoplatform/antimalware/connector/ClamAVMalwareDetectionConnector.java
+++ b/anti-malware-services/src/main/java/org/exoplatform/antimalware/connector/ClamAVMalwareDetectionConnector.java
@@ -29,21 +29,22 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.stream.Stream;
 
 @Component
 public class ClamAVMalwareDetectionConnector extends MalwareDetectionConnector {
 
-  private static final Log LOG        = ExoLogger.getExoLogger(ClamAVMalwareDetectionConnector.class);
+  private static final Log        LOG        = ExoLogger.getExoLogger(ClamAVMalwareDetectionConnector.class);
 
   @Value("${exo.malwareDetection.connector.clamav.report.path:${exo.data.dir}/clamav-report.txt}")
-  private String    reportPath = null;
+  private String                  reportPath = null;
 
   @Value("${exo.malwareDetection.connector.clamav.isDefault:false}")
-  private boolean   isDefault  = false;
+  private boolean                 isDefault  = false;
 
-  private String    type       = "ClamAV";
+  private String                  type       = "ClamAV";
 
   @Autowired
   private MalwareDetectionService malwareDetectionService;
@@ -62,21 +63,21 @@ public class ClamAVMalwareDetectionConnector extends MalwareDetectionConnector {
     }
 
     Path path = Paths.get(reportPath);
-    if (!Files.exists(path)) {
+    if (!Files.exists(path) || isFileEmpty(path)) {
       return List.of();
     }
 
     try (Stream<String> lines = Files.lines(path)) {
       // Collect infected paths
       List<String> infectedPaths =
-              lines.filter(line -> !line.isBlank() && line.contains("FOUND"))
-                   .map(line -> {
-                     int idx = line.lastIndexOf(':');
-                     return idx > 0 ? line.substring(0, idx).trim() : null;})
-                    .filter(p -> p != null && !p.isEmpty())
-                    .toList();
+            lines.filter(line -> !line.isBlank() && line.contains("FOUND"))
+                 .map(line -> {
+                   int idx = line.lastIndexOf(':');
+                   return idx > 0 ? line.substring(0, idx).trim() : null;})
+                 .filter(p -> p != null && !p.isEmpty())
+                 .toList();
 
-      deleteReportFile(path);
+      clearReportFile(path);
 
       return infectedPaths;
     } catch (IOException e) {
@@ -84,13 +85,22 @@ public class ClamAVMalwareDetectionConnector extends MalwareDetectionConnector {
       return List.of();
     }
   }
-  
-  private void deleteReportFile(Path path) {
+
+  private void clearReportFile(Path path) {
     try {
-      Files.delete(path);
-      LOG.debug("ClamAV report file deleted after processing: {}", reportPath);
+      Files.newBufferedWriter(path, StandardOpenOption.TRUNCATE_EXISTING).close();
+      LOG.debug("ClamAV report file truncated after processing: {}", reportPath);
     } catch (IOException ex) {
-      LOG.warn("Failed to delete ClamAV report file: {}", reportPath, ex);
+      LOG.warn("Failed to truncate ClamAV report file: {}", reportPath, ex);
+    }
+  }
+
+  private boolean isFileEmpty(Path path) {
+    try {
+      return Files.size(path) == 0;
+    } catch (IOException e) {
+      LOG.warn("Failed to check if ClamAV report file is empty: {}", reportPath, e);
+      return false;
     }
   }
 }

--- a/anti-malware-services/src/test/java/org/exoplatform/antimalware/connector/ClamAVMalwareDetectionConnectorTest.java
+++ b/anti-malware-services/src/test/java/org/exoplatform/antimalware/connector/ClamAVMalwareDetectionConnectorTest.java
@@ -76,8 +76,8 @@ class ClamAVMalwareDetectionConnectorTest {
     assertTrue(infected.contains("/tmp/malware.exe"));
     assertTrue(infected.contains("C:\\Users\\John\\infected.doc"));
 
-    // verify the file is deleted
-    assertFalse(Files.exists(tempReport), "ClamAV report file should be deleted after reading");
+    // Verify the report file was truncated (cleared)
+    assertEquals(0, Files.size(tempReport), "ClamAV report file should be truncated (empty) after reading");
   }
 
   @Test


### PR DESCRIPTION
Truncate ClamAV report instead of delete after being processed