### PR TITLE
fix: Enhance Analytics Field Data Types - MEEDS-10142 - Meeds-io/meeds#3994

### DIFF
--- a/anti-malware-services/src/test/java/org/exoplatform/antimalware/listener/AntiMalwareAnalyticsListenerTest.java
+++ b/anti-malware-services/src/test/java/org/exoplatform/antimalware/listener/AntiMalwareAnalyticsListenerTest.java
@@ -83,7 +83,7 @@ public class AntiMalwareAnalyticsListenerTest {
 
       assertEquals("AntiMalware", data.getModule());
       assertEquals("antimalwareCheck", data.getOperation());
-      assertEquals(String.valueOf(infectedCount), data.getParameters().get("infectedFilesCount"));
+      assertEquals(infectedCount, data.getParameters().get("infectedFilesCount"));
       assertEquals(connectorType, data.getParameters().get("connectorType"));
 
       ArgumentCaptor<StatisticData> captor1 = ArgumentCaptor.forClass(StatisticData.class);


### PR DESCRIPTION
Prior to this change, the `StatisticData` parameters of type Long were converted to String. After deleting the Numeric Auto Detection from Elasticsearch Mapping, the Long values will be stored as Long instead of String. Thus the data type in parameters isn't normalized anymore to use String and must be explicitly be of type String. This change will fix the data type detection in Unit Tests.

Resolves Meeds-io/meeds#3994