### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/anti-malware-services/src/main/java/org/exoplatform/antimalware/listener/AntiMalwareAnalyticsListener.java
+++ b/anti-malware-services/src/main/java/org/exoplatform/antimalware/listener/AntiMalwareAnalyticsListener.java
@@ -81,8 +81,8 @@ public class AntiMalwareAnalyticsListener extends Listener<String, Object> {
     StatisticData scanStatistics = new StatisticData();
     scanStatistics.setModule("AntiMalware");
     scanStatistics.setOperation("antimalwareCheck");
-    scanStatistics.addParameter("infectedFilesCount", infectedFilesCount);
-    scanStatistics.addParameter("connectorType", connectorType);
+    scanStatistics.addLong("infectedFilesCount", infectedFilesCount);
+    scanStatistics.addKeyword("connectorType", connectorType);
     AnalyticsUtils.addStatisticData(scanStatistics);
   }
 
@@ -90,11 +90,11 @@ public class AntiMalwareAnalyticsListener extends Listener<String, Object> {
     StatisticData fileRemovalStatistics = new StatisticData();
     fileRemovalStatistics.setModule("AntiMalware");
     fileRemovalStatistics.setOperation("InfectedFileRemoval");
-    fileRemovalStatistics.addParameter("fileId", infectedItem.get(INFECTED_FILE_ID));
-    fileRemovalStatistics.addParameter("fileName", infectedItem.get(INFECTED_FILE_NAME));
-    fileRemovalStatistics.addParameter("filePath", infectedItem.get(INFECTED_FILE_PATH));
-    fileRemovalStatistics.addParameter("fileAuthor", infectedItem.get(INFECTED_FILE_LAST_MODIFIER));
-    fileRemovalStatistics.addParameter("connectorType", connectorType);
+    fileRemovalStatistics.addKeyword("fileId", infectedItem.get(INFECTED_FILE_ID));
+    fileRemovalStatistics.addKeyword("fileName", infectedItem.get(INFECTED_FILE_NAME));
+    fileRemovalStatistics.addKeyword("filePath", infectedItem.get(INFECTED_FILE_PATH));
+    fileRemovalStatistics.addKeyword("fileAuthor", infectedItem.get(INFECTED_FILE_LAST_MODIFIER));
+    fileRemovalStatistics.addKeyword("connectorType", connectorType);
     AnalyticsUtils.addStatisticData(fileRemovalStatistics);
   }
 }

--- a/anti-malware-services/src/test/java/org/exoplatform/antimalware/listener/AntiMalwareAnalyticsListenerTest.java
+++ b/anti-malware-services/src/test/java/org/exoplatform/antimalware/listener/AntiMalwareAnalyticsListenerTest.java
@@ -61,7 +61,7 @@ public class AntiMalwareAnalyticsListenerTest {
   @Test
   public void testOnEvent() throws Exception {
     String connectorType = "ClamAV";
-    int infectedCount = 5;
+    long infectedCount = 5;
     Map<String, String> infectedFile = new HashMap<>();
     infectedFile.put("infectedItemId", "1");
     infectedFile.put("infectedItemName", "filetesteicar.txt");

--- a/anti-malware-webapp/package-lock.json
+++ b/anti-malware-webapp/package-lock.json
@@ -5298,9 +5298,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.