### PR TITLE
fix: Remove the legacy digest hooks of the notifications - EXO-90072 - eXIP7.3.0.22

### DIFF
--- a/anti-malware-services/src/main/java/org/exoplatform/antimalware/notification/provider/MailTemplateProvider.java
+++ b/anti-malware-services/src/main/java/org/exoplatform/antimalware/notification/provider/MailTemplateProvider.java
@@ -16,8 +16,6 @@
  */
 package org.exoplatform.antimalware.notification.provider;
 
-import java.io.Writer;
-
 import org.exoplatform.antimalware.connector.MalwareDetectionItemConnector;
 import org.exoplatform.antimalware.notification.plugin.MalwareDetectionPlugin;
 import org.exoplatform.commons.api.notification.NotificationContext;
@@ -74,11 +72,6 @@ public class MailTemplateProvider extends TemplateProvider {
       notificationContext.setException(templateContext.getException());
 
       return messageInfo.subject(subject).body(body).end();
-    }
-
-    @Override
-    protected boolean makeDigest(NotificationContext notificationContext, Writer writer) {
-      return false;
     }
   }
 }


### PR DESCRIPTION
> **Depends on Meeds-io/commons#782**, which removes the legacy digest engine of the platform and with it the `makeDigest` hook. This branch is red until that one is merged, hence the draft. Task EXO-90072.

## What

The digest engine of commons was switched off in 2022 (its job crons were pushed to year 2099) and eXIP 7.3.0.22 removes it, replaced by `io.meeds.commons.digest`. `makeDigest` was an **abstract** method of `AbstractNotificationPlugin` / `AbstractTemplateBuilder`, so every notification plugin had to implement it: this addon carried overrides that were never called. They go, with the imports that only served them.

Changed: 1 file changed, 7 deletions(-) — MailTemplateProvider.java

No behaviour change: the instant emails and the push notifications are untouched, and this addon has no digest translation key.

## Checked

Built against the cleaned commons and social of the same wave, in a cross-repository build that installs each repository in dependency order (commons → social → the addons) to prove the whole set compiles together.

N2 (addon, no schema, no security). 🤖 Generated with [Claude Code](https://claude.com/claude-code)